### PR TITLE
Remove space and background color on menubar

### DIFF
--- a/chrome/tabs_on_bottom_menubar_on_top_patch.css
+++ b/chrome/tabs_on_bottom_menubar_on_top_patch.css
@@ -6,18 +6,18 @@ See the above repository for updates as well as full license text. */
 
 :root:not([sizemode="fullscreen"]){ --uc-window-control-width: 0px !important }
 
-#navigator-toolbox{ padding-top: calc(29px + var(--uc-titlebar-padding,0px)) !important }
+#navigator-toolbox{ padding-top: calc(20px + var(--uc-titlebar-padding,0px)) !important }
 :root[sizemode="fullscreen"] #navigator-toolbox{ padding-top: 0px !important; }
 #toolbar-menubar{
   position: fixed;
   display: flex;
   top: var(--uc-titlebar-padding,0px);
-  height: 29px;
+  height: 20px;
   width: 100%;
   overflow: hidden;
 }
 
-#toolbar-menubar > .titlebar-buttonbox-container{ height: 29px; order: 100; }
+#toolbar-menubar > .titlebar-buttonbox-container{ height: 20px; order: 100; }
 
 #toolbar-menubar > [flex]{ flex-grow: 100; }
 #toolbar-menubar > spacer[flex]{
@@ -29,3 +29,5 @@ See the above repository for updates as well as full license text. */
 #toolbar-menubar .titlebar-button{ padding: 2px 17px !important;  }
 
 #toolbar-menubar .toolbarbutton-1 { --toolbarbutton-inner-padding: 3px }
+
+#main-menubar {	background-color: transparent !important; } 

--- a/chrome/tabs_on_bottom_menubar_on_top_patch.css
+++ b/chrome/tabs_on_bottom_menubar_on_top_patch.css
@@ -30,4 +30,4 @@ See the above repository for updates as well as full license text. */
 
 #toolbar-menubar .toolbarbutton-1 { --toolbarbutton-inner-padding: 3px }
 
-#main-menubar {	background-color: transparent !important; } 
+#main-menubar { background-color: transparent !important; }


### PR DESCRIPTION
Removes extra space and background color from bottom of menu bar so it looks less out of place.

## Screenshots

[Before](http://venus.morante.net/downloads/unibia/screenshots/firefox-tabs-in-middle-before.png):
![image](https://user-images.githubusercontent.com/5660265/120900111-11277e80-c601-11eb-8cf0-a808f3dee0d2.png)

[After](http://venus.morante.net/downloads/unibia/screenshots/firefox-tabs-in-middle-after.png): 
![image](https://user-images.githubusercontent.com/5660265/120900117-15539c00-c601-11eb-96fa-e2df121b9df4.png)
