### PR TITLE
Notifications using firefox's cssvars

### DIFF
--- a/chrome/proton_dark_light_notifications.css
+++ b/chrome/proton_dark_light_notifications.css
@@ -4,7 +4,14 @@ See the above repository for updates as well as full license text. */
 /* Makes web notifications use dark/light theme based on your selected theme, and makes them fit a bit better to rounded proton style. */
 
 @-moz-document url("chrome://global/content/alerts/alert.xhtml") {
-  #alertBox{ border-radius: 6px !important; }
+  #alertBox {
+    color: var(--menu-color) !important;
+    background-color: var(--menu-background-color) !important;
+    border-color: var(--menu-border-color) !important;
+    border-radius: 6px !important;
+    -moz-window-shadow: cliprounded !important;
+  }
+
   #alertSettings {
     fill: currentColor !important;
     color: inherit !important;
@@ -12,30 +19,33 @@ See the above repository for updates as well as full license text. */
     margin-inline: 0 !important;
     margin-bottom: -4px !important;
   }
-  #alertSettings, 
-  .close-icon{ background: transparent !important }
-  
-  .close-icon:hover > .toolbarbutton-icon,
-  #alertSettings:is(:hover,[open]) > .button-box{
-    background-color: rgba(0,0,0,.09) !important;
-  }
   #alertSettings > .button-box,
   .close-icon > .toolbarbutton-icon{
+    border-radius: 4px !important;
     padding: 2px !important;
     margin: 2px 2px -2px 0 !important;
-    border-radius: 4px !important;
   }
-  #alertSettings > .button-box > .box-inherit > .button-icon { padding: 1px }
-  #alertSettings > .button-box{ margin: -4px 4px 3px 0 !important; }
-  
-  @media (-moz-toolbar-prefers-color-scheme:dark){
-    #alertBox {
-      border-color: rgba(107,107,107,.3) !important;
-      background-color: rgb(43,42,51) !important;
-      color: rgba(215,215,215,.9) !important;
+  #alertSettings > .button-box {
+    margin: -4px 4px 3px 0 !important;
+  }
+  #alertSettings > .button-box > .box-inherit > .button-icon {
+    padding: 1px;
+  }
+
+  /* Color */
+  #alertSettings,
+  .close-icon {
+    background: transparent !important
+  }
+  .close-icon:hover > .toolbarbutton-icon,
+  #alertSettings:is(:hover,[open]) > .button-box {
+    background-color: var(--menuitem-hover-background-color) !important;
+  }
+
+  @media (-moz-toolbar-prefers-color-scheme:dark) {
+    :root {
+      --menu-border-color: rgba(107,107,107,.3) !important;
     }
-    .close-icon:hover > .toolbarbutton-icon,
-    #alertSettings:is(:hover,[open]) > .button-box { background-color: rgba(215,215,215,.1) !important; }
     #alertSourceLabel {
       color: rgb(5,209,241) !important;
     }


### PR DESCRIPTION
We can use `global.css`'s `-moz-windows-non-native-menus` css vars
https://github.com/mozilla/gecko-dev/blob/f213971fbd82ada22c2c4e2072f729c3799ec563/toolkit/themes/windows/global/global.css#L17-L67

Implemented by referring to Popup definition.
https://github.com/mozilla/gecko-dev/blob/f213971fbd82ada22c2c4e2072f729c3799ec563/toolkit/themes/windows/global/popup.css#L32-L62

Borer color was too bright in dark mode and the highlight color doesn't exist, so we keep the current implementation.

---

Here is how to show
https://www.bennish.net/web-notifications.html
![light mode notification](https://user-images.githubusercontent.com/25581533/124379189-0c5bf600-dca5-11eb-8303-b91c52c22e1d.png)
![dark mode notification](https://user-images.githubusercontent.com/25581533/124379176-fa7a5300-dca4-11eb-841a-5dd28701ebda.png)