### PR TITLE
Centered tab label vertical align to center

### DIFF
--- a/chrome/centered_tab_label.css
+++ b/chrome/centered_tab_label.css
@@ -1,7 +1,7 @@
 /* Source file https://github.com/MrOtherGuy/firefox-csshacks/tree/master/chrome/centered_tab_label.css made available under Mozilla Public License v. 2.0
 See the above repository for updates as well as full license text. */
 
-.tab-label-container{ display: grid; justify-content: safe center }
+.tab-label-container{ display: grid; justify-content: safe center; align-items: safe center; }
 .tab-label,.tab-secondary-label{ overflow: hidden }
 .tabbrowser-tab[selected]:not(:hover) .tab-label-container,
 #tabbrowser-tabs:not([closebuttons="activetab"]) .tabbrowser-tab:not(:hover,[pinned]) .tab-label-container{ margin-inline-end: 7px }


### PR DESCRIPTION
**Screen Shot**
Apply vertical alignment.

Before:
![image](https://user-images.githubusercontent.com/25581533/159203214-99c413ec-ff4f-4656-9801-b34ba321876c.png)

After:
![image](https://user-images.githubusercontent.com/25581533/159203262-48075b1c-4492-42be-9f03-2c983c47a627.png)

**Environment**
Linux, FF v99.0b3