### PR TITLE
Window control placeholder consider titlebar mode's fullscreen

### DIFF
--- a/chrome/window_control_placeholder_support.css
+++ b/chrome/window_control_placeholder_support.css
@@ -10,14 +10,14 @@ See the above repository for updates as well as full license text. */
 
 /* Defaults for window controls on RIGHT side of the window */
 /* Modify these values to match your preferences */
-:root[tabsintitlebar]{
+:root:is([tabsintitlebar], [sizemode="fullscreen"]) {
   --uc-window-control-width: 138px; /* Space reserved for window controls (Win10) */
   /* Extra space reserved on both sides of the nav-bar to be able to drag the window */
   --uc-window-drag-space-pre: 30px; /* left side*/
   --uc-window-drag-space-post: 30px; /* right side*/
 }
 
-:root[tabsintitlebar][sizemode="maximized"] {
+:root:is([tabsintitlebar][sizemode="maximized"], [sizemode="fullscreen"]) {
   --uc-window-drag-space-pre: 0px; /* Remove pre space */
 }
 
@@ -25,7 +25,7 @@ See the above repository for updates as well as full license text. */
         (-moz-platform: windows-win8),
         (-moz-os-version: windows-win7),
         (-moz-os-version: windows-win8){
-  :root[tabsintitlebar] {
+  :root:is([tabsintitlebar], [sizemode="fullscreen"]) {
     --uc-window-control-width: 105px;
   }
 }
@@ -62,7 +62,9 @@ See the above repository for updates as well as full license text. */
 /* Use this pref to check Mac OS where window controls are on left */
 /* This pref defaults to true on Mac and doesn't actually do anything on other platforms. So if your system has window controls on LEFT side you can set the pref to true */
 @supports -moz-bool-pref("layout.css.osx-font-smoothing.enabled"){
-  :root{ --uc-window-control-width: 72px; }
+  :root:is([tabsintitlebar], [sizemode="fullscreen"]) {
+    --uc-window-control-width: 72px;
+  }
   :root[tabsintitlebar="true"]:not([inFullscreen]) #nav-bar{
     border-inline-width: calc(var(--uc-window-control-width,0px) + var(--uc-window-drag-space-post,0px)) var(--uc-window-drag-space-pre,0px)
   }


### PR DESCRIPTION
**Environment**
Linux, 100.0a1

---

Set to titlebar
![image](https://user-images.githubusercontent.com/25581533/159638693-d46532ea-16a6-47fb-b097-5e18142452b9.png)


**Before - At fullscreen**
Doesn't apply placehoder.

![image](https://user-images.githubusercontent.com/25581533/159640828-dd6f3280-9f13-4e7d-9c96-691a41b7f958.png)

**After - At fullscreen**
Applied.

![image](https://user-images.githubusercontent.com/25581533/159641022-ed361f9e-1ce4-4cf1-b6aa-37ce5a65ed52.png)

---

![image](https://user-images.githubusercontent.com/25581533/159642868-2fae9588-07c2-4bee-97a4-9cabdea3c938.png)

**Before - At fullscreen**
Exist pre space.

![image](https://user-images.githubusercontent.com/25581533/159642624-222f7f16-93f5-45fb-8d56-256408a260cd.png)

**After - At fullscreen**
Remove pre space like `[sizemode="maximized"]`.

![image](https://user-images.githubusercontent.com/25581533/159642377-e34ad949-97f8-4a26-9794-595daab38a8a.png)

---

**Bug fix**

Mac's `:root` selector is not apply. (Selector priority)

```css
:root[tabsintitlebar]{
  --uc-window-control-width: 138px; /* Space reserved for window controls (Win10) */
  /* Extra space reserved on both sides of the nav-bar to be able to drag the window */
  --uc-window-drag-space-pre: 30px; /* left side*/
  --uc-window-drag-space-post: 30px; /* right side*/
}

@supports -moz-bool-pref("layout.css.osx-font-smoothing.enabled"){
  :root{ --uc-window-control-width: 72px; }
}
```

Must use
```css
@supports -moz-bool-pref("layout.css.osx-font-smoothing.enabled"){
  :root:is([tabsintitlebar]) {
    --uc-window-control-width: 72px;
  }
}
```