### PR TITLE
Tabs on bottom at menubar

### DIFF
--- a/chrome/tabs_on_bottom.css
+++ b/chrome/tabs_on_bottom.css
@@ -58,6 +58,14 @@ linux_gtk_window_control_patch.css
 
 @media (-moz-gtk-csd-close-button){ .titlebar-button{ -moz-box-orient: vertical } }
 
+/* At Activated Menubar */
+:root:not([chromehidden~="menubar"], [sizemode="fullscreen"]) #toolbar-menubar:not([autohide="true"]) + #TabsToolbar > .titlebar-buttonbox-container {
+  display: block !important;
+}
+:root:not([chromehidden~="menubar"]) #toolbar-menubar:not([autohide="true"]) .titlebar-buttonbox-container {
+  visibility: hidden;
+}
+
 /* These exist only for compatibility with autohide-tabstoolbar.css */
 toolbox#navigator-toolbox > toolbar#nav-bar.browser-toolbar{ animation: none; }
 #navigator-toolbox:hover #TabsToolbar{ animation: slidein ease-out 48ms 1 }


### PR DESCRIPTION
Tested on Linux nightly 100a.

Titlebar button box must always appear at the top.

Before:
![image](https://user-images.githubusercontent.com/25581533/160038960-3ae6c18d-9e3f-4fc5-8f53-1c71cc48a53d.png)

After:
![image](https://user-images.githubusercontent.com/25581533/160039008-d6346152-3662-48eb-bcee-284e4fb1400c.png)
