### PR TITLE
Create newtab_button_always_on_hover.css

### DIFF
--- a/chrome/newtab_button_always_on_hover.css
+++ b/chrome/newtab_button_always_on_hover.css
@@ -1,0 +1,10 @@
+/* Source file https://github.com/MrOtherGuy/firefox-csshacks/tree/master/chrome/newtab_button_always_on_hover.css made available under Mozilla Public License v. 2.0
+See the above repository for updates as well as full license text. */
+
+/* Always show tab close button on hover and never otherwise */
+#tabbrowser-tabs #tabs-newtab-button{
+  display:none;
+}
+#tabbrowser-tabs:hover #tabs-newtab-button{
+  display:-moz-box !important;
+}


### PR DESCRIPTION
This is based on `tab_close_button_always_on_hover.css`: hide by default the newtab button, show it when hovering the tabs bar.