### PR TITLE
Update vertical_bookmarks_toolbar.css

### DIFF
--- a/chrome/vertical_bookmarks_toolbar.css
+++ b/chrome/vertical_bookmarks_toolbar.css
@@ -39,9 +39,9 @@ See the above repository for updates as well as full license text. */
   #PersonalToolbar #PlacesToolbarItems > .bookmark-item{ padding-block: 4px !important; }
   
 
-  body > #browser,
-  body > #browser-bottombox,
-  #customization-container{
+:root:not([chromehidden~="toolbar"]) body > #browser,
+:root:not([chromehidden~="toolbar"]) body > #browser-bottombox,
+:root:not([chromehidden~="toolbar"]) #customization-container{
     margin-left: var(--uc-vertical-toolbar-width,0);
   }
 


### PR DESCRIPTION
This change makes compatible with pop-up windows. I use extensions that creates new pup-up windows and looks bad with that space in blank. this affects to other windows than don't use tabs.