### PR TITLE
Fix empty tab rows on Firefox 107

### DIFF
--- a/chrome/multi-row_tabs.css
+++ b/chrome/multi-row_tabs.css
@@ -46,7 +46,7 @@ See the above repository for updates as well as full license text. */
 .scrollbox-clip[orient="horizontal"],
 #tabbrowser-arrowscrollbox{
   overflow: -moz-hidden-unscrollable;
-  display: block;
+  display: inline;
   --scrollbutton-display-model: none;
 }
 


### PR DESCRIPTION
On Firefox 107, the tab bar displays all the tab rows, even if they are empty because there are few tabs.

This change removes the empty tab rows and restores the right behavior, only displaying tab rows when there are too many tabs to fit in one row.