### PR TITLE
Update multi-row_tabs_separate_pinned_row_patch.css

### DIFF
--- a/chrome/multi-row_tabs_separate_pinned_row_patch.css
+++ b/chrome/multi-row_tabs_separate_pinned_row_patch.css
@@ -3,7 +3,7 @@ See the above repository for updates as well as full license text. */
 
 /* Use with multi-row_tabs.css to show pinned tabs on separate row. */
 
-scrollbox[part][orient="horizontal"]::after{
+scrollbox[part][orient="horizontal"]:hover::after{
   display: flow-root list-item;
   content: "";
   flex-basis: -moz-available;


### PR DESCRIPTION
just a suggestion. you only need the rows separate when you drag tabs, which coincides with :hover.

this way it'll normally display only one row when all tabs would fit in there, which is usually the case, thereby save space, and only show two rows for dragging.