### PR TITLE
Update window_control_placeholder_support.css to compatibility with window controls on left on linux

### DIFF
--- a/chrome/window_control_placeholder_support.css
+++ b/chrome/window_control_placeholder_support.css
@@ -35,6 +35,25 @@ See the above repository for updates as well as full license text. */
     --uc-window-control-width: 84px;
   }
 }
+@media (-moz-gtk-csd-reversed-placement){
+  :root:is([tabsintitlebar][sizemode="fullscreen"]) {
+  --uc-window-drag-space-post: 0px; /* right side 0px in fullscreen*/
+}
+  :root:is([tabsintitlebar],[sizemode="fullscreen"]) {
+    --uc-window-control-width: 0px !important;
+    --uc-window-control-width-left: 84px !important;
+  }
+:root[sizemode="fullscreen"] #TabsToolbar > .titlebar-buttonbox-container:last-child,
+:root[sizemode="fullscreen"] #window-controls{
+    left: 0px;
+    }
+/* left space from "back" button for window controls */
+:root:not([chromehidden~="toolbar"]) #back-button{
+    display: block !important;
+    padding-inline-start: 0px !important;
+    margin-left: var(--uc-window-control-width-left, 0px) !important;
+  }
+}
 
 /* macOS settings are further below */
 .titlebar-buttonbox, #window-controls{ color: var(--toolbar-color) }


### PR DESCRIPTION
hi,
I was testing in manjaro-kde linux OS this style and added some compatibility to window controls when they are on left side using the respective rule to affect only on this mode.
I used the back button to make space for those window controls.