### PR TITLE
fix flicker glitch

### DIFF
--- a/chrome/shrinking_pinned_tabs.css
+++ b/chrome/shrinking_pinned_tabs.css
@@ -21,3 +21,8 @@ See the above repository for updates as well as full license text. */
 .tab-label-container[pinned] {
   display: none;
 }
+
+/* Fixes flicker glitch. */
+#tabbrowser-tabs[positionpinnedtabs] > #tabbrowser-arrowscrollbox::part(scrollbox) {
+    padding-inline: unset !important;
+}

--- a/chrome/shrinking_pinned_tabs.css
+++ b/chrome/shrinking_pinned_tabs.css
@@ -23,6 +23,6 @@ See the above repository for updates as well as full license text. */
 }
 
 /* Fixes flicker glitch. */
-#tabbrowser-tabs[positionpinnedtabs] > #tabbrowser-arrowscrollbox::part(scrollbox) {
+scrollbox[part][orient="horizontal"] {
     padding-inline: unset !important;
 }


### PR DESCRIPTION
Overrides a rule in browser.css that causes the scrollbox to flicker between padding and no padding under certain circumstances.