### PR TITLE
Create gapless_close_window_button.css

### DIFF
--- a/chrome/gapless_close_window_button.css
+++ b/chrome/gapless_close_window_button.css
@@ -1,0 +1,8 @@
+/*This stylesheet removes the gap between the close window button and the corner of the browser window which appears when the title bar is disabled.
+This allows clicking this button when the browser is in fullscreen and the mouse pointer is in the very top right corner of the screen, as would be the expected behavior.*/
+
+.titlebar-buttonbox {
+  -moz-box-align: start !important;
+  margin-top: -1px !important;
+  appearance: unset !important;
+}


### PR DESCRIPTION
Fix for an issue where the button isn't clickable in the top right pixel of the screen when Firefox is fullscreen.

I honestly don't know how specific this problem is to my distro and window manager. But it's very annoying.