### PR TITLE
Popup windows without toolbars don't need padding

### DIFF
--- a/chrome/multi-row_tabs_below_content.css
+++ b/chrome/multi-row_tabs_below_content.css
@@ -77,7 +77,7 @@ See the above repository for updates as well as full license text. */
   /* Fullscreen mode support */
   #customization-container,
   :root:not([inFullscreen]) #content-deck,
-  :root:not([inFullscreen]) #browser{
+  :root:not([chromehidden~="toolbar"]):not([inFullscreen]) #browser {
     margin-top: calc(var(--multirow-toolbar-height) + var(--multirow-top-padding) + var(--multirow-menubar-height,0px));
   }
   :root[inFullscreen] #toolbar-menubar,


### PR DESCRIPTION
I use the [Popup Window extension](https://addons.mozilla.org/en-US/firefox/addon/popup-window) in Firefox which hides toolbars for popup windows. For that type of window, margin-top on the browser hbox doesn't need to be applied.