### PR TITLE
Add-Bookmark dialog too small

### DIFF
--- a/chrome/bookmark_panel_enlarge.css
+++ b/chrome/bookmark_panel_enlarge.css
@@ -1,0 +1,39 @@
+/* Source file https://github.com/MrOtherGuy/firefox-csshacks/tree/master/chrome/bookmark_panel_enlarge.css made available under Mozilla Public License v. 2.0
+See the above repository for updates as well as full license text. */
+
+/* Makes the Edit Bookmark dialog panel wider and the folder tree larger */
+
+/* Width Section */
+
+#editBookmarkPanel {
+  width: max(50vw, 32em);
+}
+
+/* Height Section */
+
+/* Choose 1 of 3:  Biggest (default), Big, or Balanced */
+
+/* (1) Biggest folder tree, for use with collapsed tag panel */
+
+#editBMPanel_folderTree {
+  height: 64vh !important;
+}
+
+/* (2) Big folder tree with default tag panel */
+
+/*
+#editBMPanel_folderTree {
+  height: 53vh !important;
+}
+*/
+
+/* (3) Balanced folder tree with larger tag panel */
+
+/*
+#editBMPanel_folderTree {
+  height: 32vh !important;
+}
+#editBMPanel_tagsSelector {
+  height: 32vh !important;
+}
+*/


### PR DESCRIPTION
# Enlarge Bookmark Panel 

## Issue

The current dialog to add or edit bookmarks is not optimized for larger screens.  Its small size causes unnecessary difficulty when trying to save a bookmark into a particular folder in a large folder hierarchy.  Here is an example of the laughably small dialog in Firefox running at 1920x1080 resolution.

<img src="https://github.com/user-attachments/assets/87048c77-862d-47fd-8dde-38d26b074ce6" width="640">

## Goal

Increase the size of the Bookmark Panel to improve usability.  

## Summary

- 3 IDs identified
- 1 file added: `chrome/bookmark_dialog_enlarge.css`
- 3 size options

## Examples at 1080

**Biggest** (default)
<img src="https://github.com/user-attachments/assets/5c7d1c79-5be7-4eec-93b4-c9a3c33ecd55" width="640">

**Big**
<img src="https://github.com/user-attachments/assets/990650f1-6821-4972-b839-d4da1541b3fe" width="640">

**Balanced**
<img src="https://github.com/user-attachments/assets/e3d5ca4a-c5fd-41cf-82bc-9827cc538596" width="640">

## Testing / Thoughts

- Tested with several different browser and monitor sizes and several official themes.
- CSS values:
  - The dialog maintains a minimum size so there should be no risk that the relative measurements will "crush" the dialog on small window sizes.
  - Width is restricted to 32em max because the I felt the dialog became less usable as it grew overly long.
- MrOtherGuy, feel free to make any changes you deem beneficial.
- Any suggestions welcome.  
