### PR TITLE
stopped unnecessary weird behaviour with window control buttons

### DIFF
--- a/chrome/toggle_tabs_toolbar_with_alt.css
+++ b/chrome/toggle_tabs_toolbar_with_alt.css
@@ -3,11 +3,26 @@ See the above repository for updates as well as full license text. */
 
 /* Show tabs toolbar with Alt-key. Menubar must be disabled for this to work */
 
+
+
 #titlebar { -moz-appearance: none !important }
+
+
+/* Combine the visibility control for tabs toolbar  */
+:root[tabsintitlebar][sizemode="maximized"] #titlebar:not(:hover) > #toolbar-menubar[autohide="true"][inactive] + #TabsToolbar {
+  visibility: collapse;
+  height: 0 !important;
+}
+
+
+
+
+/*
 :root[tabsintitlebar][sizemode="maximized"]{ padding-top: 8px !important; }
 #titlebar:not(:hover) > #toolbar-menubar[autohide="true"][inactive] + #TabsToolbar { visibility: collapse }
 
 /* Behavior 1 - Alt-key toggles menubar as normal */
+/*
 #titlebar:hover > #toolbar-menubar[autohide="true"]{ height: calc(var(--tab-min-height) + var(--space-above-tabbar) - var(--tabs-navbar-shadow-size)) !important; }
 
 /* Behavior 2 - Alt-key only shows tabs toolbar */
@@ -15,4 +30,3 @@ See the above repository for updates as well as full license text. */
 /*
 #toolbar-menubar[autohide]:not([inactive]),
 #toolbar-menubar[autohide="true"]:not([inactive]) + #TabsToolbar > .titlebar-buttonbox-container{ visibility: collapse !important }
-*/


### PR DESCRIPTION
for me at least when using toggle_tabs_toolbar_with_alt.css the behaviour was opposite (one hiding other showing and vice a versa ) between the tabs toolbar and the close minimise maximise buttons, found that annoying and unnecessary. "fixed" it.

(was using the css along with some others like tabs on bottom,multi row, windows placement patch(most likely this one causing it) etc etc, could be because of that but regardless it should be better now) (old code was just commented incase someone else wants to use that)

only thing is the menu bar shows up everytime but i guess having something small there, is better than not even having the option as it needs to be disabled in the original css (besides you can just uncomment the old code if you dont want it).

(disclaimer - havnt extensively tested it with different css combinations and all)