### PR TITLE
Fix titlebar buttonbox position

### DIFF
--- a/chrome/hide_tabs_toolbar_osx.css
+++ b/chrome/hide_tabs_toolbar_osx.css
@@ -12,6 +12,9 @@ Window controls will be all wrong without it
 :root{ --uc-toolbar-height: 32px; }
 :root:not([uidensity="compact"]){ --uc-toolbar-height: 34px }
 
+#TabsToolbar {
+  justify-content: start !important;
+}
 #TabsToolbar > *{ visibility: collapse !important }
 #TabsToolbar > .titlebar-buttonbox-container{
   visibility: visible !important;


### PR DESCRIPTION
Recently I noticed the position of titlebar buttonbox displayed incorrectly on my OSX when using hide_tabs_toolbar_osx.css and window_control_placeholder_support.css

Without the fix:
![Screenshot 2025-01-27 at 1 58 58 PM](https://github.com/user-attachments/assets/e1ac56aa-2cee-41df-81fd-d9ad39312c52)

With the fix:
![Screenshot 2025-01-27 at 1 58 20 PM](https://github.com/user-attachments/assets/9a168959-087e-4751-9048-c9ca4d403f64)
