### PR TITLE
Enable collapsing of tab groups in multi-row tabs

### DIFF
--- a/chrome/multi-row_tabs.css
+++ b/chrome/multi-row_tabs.css
@@ -84,3 +84,8 @@ See the above repository for updates as well as full license text. */
        -moz-pref( "userchrome.multirowtabs.scrollbar-handle.enabled"){
   #tabbrowser-arrowscrollbox{ -moz-window-dragging: no-drag }
 }
+
+/* Make tab groups collapse */
+tab-group[collapsed] .tabbrowser-tab[fadein]:not([pinned]){
+  min-width: 0 !important;
+}


### PR DESCRIPTION
In Firefox 136.0 with `browser.tabs.groups.enabled` we can preview the upcoming tab group feature. This already works reasonably well with multi-row_tabs.css (although drag and drop has some issues). 

However, when tab groups are collapsed, their width is set to zero which multi-row_tabs.css currently prevents. This pull request fixes this, allowing tab groups to properly collapse. 