### PR TITLE
Makes the bookmarks toolbar scrollable

### DIFF
--- a/chrome/scrollable_bookmarks_toolbar.css
+++ b/chrome/scrollable_bookmarks_toolbar.css
@@ -1,4 +1,4 @@
-/* Source file https://github.com/MrOtherGuy/firefox-csshacks/tree/master/chrome/scrollable_urlbar_popup.css made available under Mozilla Public License v. 2.0
+/* Source file https://github.com/MrOtherGuy/firefox-csshacks/tree/master/chrome/scrollable_bookmarks_toolbar.css made available under Mozilla Public License v. 2.0
 See the above repository for updates as well as full license text. */
 
 /* Makes the bookmarks toolbar scrollable via mouse scroll or scrollbar */
@@ -24,13 +24,13 @@ See the above repository for updates as well as full license text. */
 }
 
 /*
-When the Browser Window reaches a smaller enough width or the amount of Bookmarks overlap the browsers width, overlapping bookmark items are:
-1. set as hidden. 
+When the Browser Window reaches a small enough width or the amount of Bookmarks overlap the browsers width, overlapping bookmark items are:
+1. set to hidden. 
 2. duplicated into the overflow menu.
 
-This style is a simple to implement and easily maintained by:
-1. enabling scrolling on the toolbar
-2. restoring visibility of hidden bookmarks.
+This style will simply:
+1. enable scrolling on the toolbar.
+2. restore visibility of hidden bookmarks.
 
-You can have both the scrollable toolbar and the overflow menu by removing Line 16-18
+You can use the scrollable toolbar alongside the overflow menu by removing Lines 16-19
 */

--- a/chrome/scrollable_bookmarks_toolbar.css
+++ b/chrome/scrollable_bookmarks_toolbar.css
@@ -3,11 +3,9 @@ See the above repository for updates as well as full license text. */
 
 /* Makes the bookmarks toolbar scrollable via mouse scroll or scrollbar */
 
-/* Enable scroll */
-
 /* allow scrolling */
 #PlacesToolbarItems {
-    overflow: auto !important;
+    overflow-x: auto !important;
 }
 
 /* restore visibility of hidden bookmarks */
@@ -18,6 +16,11 @@ See the above repository for updates as well as full license text. */
 /* hide overflow menu */
 #PlacesToolbar #PlacesChevron {
     visibility: collapse !important;
+}
+
+/* force thin scrollbar */
+#PlacesToolbarItems {
+    scrollbar-width: thin !important;
 }
 
 /*

--- a/chrome/scrollable_bookmarks_toolbar.css
+++ b/chrome/scrollable_bookmarks_toolbar.css
@@ -1,0 +1,33 @@
+/* Source file https://github.com/MrOtherGuy/firefox-csshacks/tree/master/chrome/scrollable_urlbar_popup.css made available under Mozilla Public License v. 2.0
+See the above repository for updates as well as full license text. */
+
+/* Makes the bookmarks toolbar scrollable via mouse scroll or scrollbar */
+
+/* Enable scroll */
+
+/* allow scrolling */
+#PlacesToolbarItems {
+    overflow: auto !important;
+}
+
+/* restore visibility of hidden bookmarks */
+.bookmark-item {
+    visibility: initial !important
+}
+
+/* hide overflow menu */
+#PlacesToolbar #PlacesChevron {
+    visibility: collapse !important;
+}
+
+/*
+When the Browser Window reaches a smaller enough width or the amount of Bookmarks overlap the browsers width, overlapping bookmark items are:
+1. set as hidden. 
+2. duplicated into the overflow menu.
+
+This style is a simple to implement and easily maintained by:
+1. enabling scrolling on the toolbar
+2. restoring visibility of hidden bookmarks.
+
+You can have both the scrollable toolbar and the overflow menu by removing Line 16-18
+*/


### PR DESCRIPTION
When the Browser Window reaches a smaller enough width, or amount of Bookmarks overlap the browser width, overlapping bookmark items are:
1. set as hidden. 
2. duplicated into the overflow menu.

This style is a simple to implement and easily maintained by:
1. enabling scrolling on the toolbar
2. restoring visibility of hidden bookmarks.

https://github.com/user-attachments/assets/61fac0e0-a685-46a8-ad93-b76940a45c44


![Vid_20250627_021159](https://github.com/user-attachments/assets/f6115b13-a235-4e6e-81db-1115f568272b)
