### PR TITLE
Update multi-row_tabs.css: grow tabs only when horizontal

### DIFF
--- a/chrome/multi-row_tabs.css
+++ b/chrome/multi-row_tabs.css
@@ -51,7 +51,7 @@ See the above repository for updates as well as full license text. */
   margin-inline-start: 0px !important;
 }
 
-.tabbrowser-tab[fadein]:not([pinned]){
+#tabbrowser-tabs[orient="horizontal"] .tabbrowser-tab[fadein]:not([pinned]){
   min-width: var(--multirow-tab-min-width) !important;
   flex-grow: var(--multirow-tab-dynamic-width) !important;
 }


### PR DESCRIPTION
With multi-row_tabs.css and vertical/sidebar tabs and just few tabs open, the tab height expands to create tall tabs. This PR fixes that by applying `min-width` and `flex-grow` only to horizontal tabs.