### PR TITLE
Align numbers with keyboard controls

### DIFF
--- a/chrome/numbered_tabs.css
+++ b/chrome/numbered_tabs.css
@@ -3,5 +3,6 @@ See the above repository for updates as well as full license text. */
 
 /* Show a number before tab text*/
 
-.tabbrowser-tab:first-child{ counter-reset: nth-tab 0 } /* Change to -1 for 0-indexing */
-.tab-text::before{ content: counter(nth-tab) " "; counter-increment: nth-tab }
+#tabbrowser-tabs{ counter-reset: nth-tab 0 } /* Change to -1 for 0-indexing */
+:not(tab-group[collapsed])>.tabbrowser-tab{ counter-increment: nth-tab }
+.tab-text::before{ content: counter(nth-tab) " " }


### PR DESCRIPTION
This is an assumption, but I imagine numbered tabs are used to know which `Alt`+`№` to press. This aligns the displayed numbers with the keyboard shortcuts (don't enumerate pinned tabs, and skip increment for **folded** tab groups)

Could also be offered as an alternative