### PR TITLE
autohide-tabstoolbar: fix hover/reveal on macOS

### DIFF
--- a/chrome/autohide_tabstoolbar_v2.css
+++ b/chrome/autohide_tabstoolbar_v2.css
@@ -79,6 +79,25 @@ See the above repository for updates as well as full license text. */
       transition-delay: 0ms, 0ms !important;
     }
   }
+  @media (-moz-platform: macos) {   
+    #navigator-toolbox:hover,
+    #navigator-toolbox:has(#alltabs-button[open]),
+    #navigator-toolbox:has(#alltabs-button[open="true"]) {
+      margin-bottom: 0px !important;
+      >#TabsToolbar {
+          visibility: visible !important;
+          margin-bottom: 0px !important;
+          transition-delay: 0ms, 0ms !important;
+      }
+    }
+    #mainPopupSet:has(#tabContextMenu[open], #tabContextMenu[open="true"], #tabContextMenu[state="open"]) ~ #navigator-toolbox {
+      margin-bottom: 0px !important;
+      > #TabsToolbar {
+          visibility: visible !important;
+          margin-bottom: 0px !important;
+      }  
+    }
+  }
   @media -moz-pref("userchrome.autohidetabs.show-while-inactive.enabled"){
     #navigator-toolbox:-moz-window-inactive{
       margin-bottom: calc(0px - 2 * var(--tab-block-margin) - var(--tab-min-height));


### PR DESCRIPTION
On macOS, `autohide_tabstoolbar_v2.css` fails to reveal tabs on hover. This change corrects the hover/reveal logic so it works properly on macOS, and also fixes a minor gap between the `TabsToolbar` and `nav-bar` during the reveal.

### Before


https://github.com/user-attachments/assets/5042df72-b15b-4732-9314-c579878eda71


<img width="1274" height="452" alt="gap" src="https://github.com/user-attachments/assets/538b5ced-7868-4132-9b95-6c090ddd4511" />


### After


https://github.com/user-attachments/assets/69953e4f-29c3-4220-8320-731894d1ce77

