### PR TITLE
urlbar popup full width: fix transparent background

### DIFF
--- a/chrome/urlbar_popup_full_width.css
+++ b/chrome/urlbar_popup_full_width.css
@@ -15,5 +15,5 @@ See the above repository for updates as well as full license text. */
   margin: var(--urlbar-container-height) 0 0 0 !important;
   width: 100vw !important;
   border-width: 1px 0;
-  background-color: var(--toolbar-field-focus-background-color, inherit);
+  background-color: var(--toolbar-field-background-color-focus, inherit);
 }


### PR DESCRIPTION
Need to change toolbar-field-focus-background-color to toolbar-field-background-color-focus to fix the urlbar popup transparent background issue, I learned it from this reddit post: https://www.reddit.com/r/FirefoxCSS/comments/1u9s9nj/comment/osj13kx/