### PR TITLE
Fixed toolbox hide animation hover/flickering on Linux

### DIFF
--- a/chrome/autohide_toolbox.css
+++ b/chrome/autohide_toolbox.css
@@ -18,6 +18,13 @@ See the above repository for updates as well as full license text. */
   :root:not([lwtheme]) #navigator-toolbox{ background-color: -moz-dialog !important; }
 }
 
+@media (-moz-platform: linux){
+  :root{
+    --uc-autohide-toolbox-delay: 0ms; /* Delay causes flickering on Wayland */
+    --uc-toolbox-rotation: 50deg; /* Increase hover hitbox for GTK windows */
+  }
+}
+
 :root[sizemode="fullscreen"],
 :root[sizemode="fullscreen"] #navigator-toolbox{ margin-top: 0 !important; }
 


### PR DESCRIPTION
On Linux (I'm using Sway/Wayland), the `autohide_toolbox.css` does not seem to
behave as intended. The hover hitbox is only a few pixels tall, making it
mostly unusable. I've decreased the rotation angle until the hover feels about
the same as Firefox's native toolbox hide behavior in fullscreen.

Furthermore, the address bar itself, apart from the rest of the toolbox, seems
not to obey the animation delay. This leads to an ugly flickering effect when
mousing over toolbox. I don't know CSS well enough to track down the real cause
of this, so I did the trivial thing and removed the delay on Linux. It's not
perfect (quickly waving the cursor back and forth over the toolbox still
creates the effect), but it's much better. If anyone has ideas for a
better-than-bandaid solution to this, I'm happy to try looking into it more!
